### PR TITLE
Fix external Auth

### DIFF
--- a/lib/components/in_app_browser.dart
+++ b/lib/components/in_app_browser.dart
@@ -1,0 +1,35 @@
+import 'dart:async';
+import 'dart:developer';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:humhub/models/manifest.dart';
+
+class MyInAppBrowser extends InAppBrowser {
+  final Manifest manifest;
+  final InAppBrowserClassOptions options = InAppBrowserClassOptions(
+    crossPlatform: InAppBrowserOptions(hideUrlBar: false, toolbarTopBackgroundColor: Colors.grey),
+    inAppWebViewGroupOptions: InAppWebViewGroupOptions(
+      crossPlatform: InAppWebViewOptions(javaScriptEnabled: true, useShouldOverrideUrlLoading: true),
+    ),
+  );
+
+  final Function concludeAuth;
+
+  MyInAppBrowser({required this.manifest, required this.concludeAuth});
+
+  @override
+  Future<NavigationActionPolicy?>? shouldOverrideUrlLoading(NavigationAction navigationAction) async {
+    log("Browser closed!");
+
+    if (navigationAction.request.url!.origin.startsWith(manifest.baseUrl)) {
+      concludeAuth(navigationAction.request);
+      return NavigationActionPolicy.CANCEL;
+    }
+    return NavigationActionPolicy.ALLOW;
+  }
+
+  launchUrl(URLRequest urlRequest) {
+    openUrlRequest(urlRequest: urlRequest, options: options);
+  }
+}

--- a/lib/components/in_app_browser.dart
+++ b/lib/components/in_app_browser.dart
@@ -1,22 +1,22 @@
 import 'dart:async';
 import 'dart:developer';
-
-import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:humhub/models/manifest.dart';
+import 'package:humhub/util/extensions.dart';
 
 class MyInAppBrowser extends InAppBrowser {
   final Manifest manifest;
-  final InAppBrowserClassOptions options = InAppBrowserClassOptions(
-    crossPlatform: InAppBrowserOptions(hideUrlBar: false, toolbarTopBackgroundColor: Colors.grey),
-    inAppWebViewGroupOptions: InAppWebViewGroupOptions(
-      crossPlatform: InAppWebViewOptions(javaScriptEnabled: true, useShouldOverrideUrlLoading: true),
-    ),
-  );
-
+  late InAppBrowserClassOptions options;
   final Function concludeAuth;
 
-  MyInAppBrowser({required this.manifest, required this.concludeAuth});
+  MyInAppBrowser({required this.manifest, required this.concludeAuth}) {
+    options = InAppBrowserClassOptions(
+      crossPlatform: InAppBrowserOptions(hideUrlBar: false, toolbarTopBackgroundColor: HexColor(manifest.themeColor)),
+      inAppWebViewGroupOptions: InAppWebViewGroupOptions(
+        crossPlatform: InAppWebViewOptions(javaScriptEnabled: true, useShouldOverrideUrlLoading: true),
+      ),
+    );
+  }
 
   @override
   Future<NavigationActionPolicy?>? shouldOverrideUrlLoading(NavigationAction navigationAction) async {

--- a/lib/models/manifest.dart
+++ b/lib/models/manifest.dart
@@ -12,11 +12,8 @@ class Manifest {
       this.backgroundColor, this.themeColor);
 
   String get baseUrl {
-    int index = startUrl.indexOf("humhub.com");
-    if (index != -1) {
-      return startUrl.substring(0, index + "humhub.com".length);
-    }
-    throw Exception("Can't define base url");
+    Uri url = Uri.parse(startUrl);
+    return url.origin;
   }
 
   factory Manifest.fromJson(Map<String, dynamic> json) {

--- a/lib/pages/web_view.dart
+++ b/lib/pages/web_view.dart
@@ -75,8 +75,11 @@ class WebViewAppState extends ConsumerState<WebViewApp> {
 
   Future<NavigationActionPolicy?> _shouldOverrideUrlLoading(InAppWebViewController controller, NavigationAction action) async {
     // 1st check if url is not def. app url and open it in a browser or inApp.
+
     final url = action.request.url!.origin;
-    if (!url.startsWith(manifest.baseUrl)) {
+
+    HumHub instance = await ref.read(humHubProvider).getInstance();
+    if (!url.startsWith(manifest.baseUrl) && instance.isHideOpener && whitelistRedirects(url)) {
       launchUrl(action.request.url!, mode: LaunchMode.externalApplication);
       return NavigationActionPolicy.CANCEL;
     }
@@ -223,5 +226,18 @@ class WebViewAppState extends ConsumerState<WebViewApp> {
         ],
       ),
     );
+  }
+
+  bool whitelistRedirects(String url) {
+    for (var element in [
+      "https://github.com/login/oauth/authorize",
+      "https://login.live.com/oauth20_authorize",
+      "https://www.facebook.com/dialog/oauth",
+      "https://discord.com/api/oauth2/authorize",
+      "https://www.linkedin.com/oauth/v2/authorization"
+    ]) {
+      if(url.contains(element)) return true;
+    }
+    return false;
   }
 }


### PR DESCRIPTION
**Modules Tested and redirect URIs added to WebView whitelist:**
LinkedIn Sign-In ✅
Facebook Sign-In ✅ 
GitHub Sign-In ✅ 
Twitter Sign-In (Didn't find documentation and I believe It's only paid version)
Discord Integrations ✅ 
Live (Microsoft) Sign in ✅ 
Two-Factor Authentication (2FA) ✅

For now, I took into the account `opener` state but I think it will be more correct in the future to just use a whitelist for URI redirects.