### PR TITLE
Feature-flag header for auth client redirect support and SSO update

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,5 +45,3 @@ To learn more about HumHub itself, visit:
 
 - https://www.humhub.com/
 - https://github.com/humhub
-
-Version bump

--- a/README.md
+++ b/README.md
@@ -45,3 +45,5 @@ To learn more about HumHub itself, visit:
 
 - https://www.humhub.com/
 - https://github.com/humhub
+
+Version bump

--- a/lib/app_flavored.dart
+++ b/lib/app_flavored.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:humhub/flavored/models/humhub.f.dart';
 import 'package:humhub/flavored/util/intent_plugin.f.dart';
 import 'package:humhub/flavored/util/router.f.dart';
+import 'package:humhub/models/remote_config.dart';
 import 'package:humhub/util/const.dart';
 import 'package:humhub/util/loading_provider.dart';
 import 'package:humhub/util/notifications/plugin.dart';
@@ -23,6 +24,7 @@ class FlavoredApp extends ConsumerStatefulWidget {
 class FlavoredAppState extends ConsumerState<FlavoredApp> {
   @override
   Widget build(BuildContext context) {
+    ref.watch(humHubFRemoteConfigProvider);
     SecureStorageService.clearSecureStorageOnReinstall();
     return LoadingProvider(
       child: IntentPluginF(
@@ -35,10 +37,12 @@ class FlavoredAppState extends ConsumerState<FlavoredApp> {
                   debugShowCheckedModeBanner: false,
                   initialRoute: RouterF.initRoute,
                   routes: RouterF.routes,
-                  localizationsDelegates: AppLocalizations.localizationsDelegates,
+                  localizationsDelegates:
+                      AppLocalizations.localizationsDelegates,
                   supportedLocales: AppLocalizations.supportedLocales,
                   navigatorKey: Keys.navigatorKey,
-                  builder: (context, child) => ConnectivityWrapper(child: child!),
+                  builder: (context, child) =>
+                      ConnectivityWrapper(child: child!),
                   theme: ThemeData(
                     fontFamily: 'OpenSans',
                   ),
@@ -54,4 +58,9 @@ class FlavoredAppState extends ConsumerState<FlavoredApp> {
 
 final humHubFProvider = Provider<HumHubF>((ref) {
   return HumHubF();
+});
+
+final humHubFRemoteConfigProvider = FutureProvider<RemoteConfig?>((ref) async {
+  final instance = ref.read(humHubFProvider);
+  return RemoteConfig.get(instance.manifest, instance.customHeaders);
 });

--- a/lib/flavored/models/humhub.f.dart
+++ b/lib/flavored/models/humhub.f.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:humhub/flavored/models/manifest.f.dart';
+import 'package:humhub/models/feature_flag.dart';
 import 'package:humhub/models/global_package_info.dart';
 import 'package:humhub/models/hum_hub.dart';
 import 'package:humhub/util/crypt.dart';
@@ -22,6 +23,7 @@ class HumHubF extends HumHub {
   Map<String, String> get customHeaders => {
         'x-humhub-app-token': randomHash!,
         'x-humhub-app': GlobalPackageInfo.info.version,
+        'x-humhub-app-feature-flags': FeatureFlag.featureFlagsHeaderValue,
         'x-humhub-app-bundle-id': GlobalPackageInfo.info.packageName,
         'x-humhub-app-is-ios': isIos ? '1' : '0',
         'x-humhub-app-is-android': isAndroid ? '1' : '0',

--- a/lib/flavored/models/humhub.f.dart
+++ b/lib/flavored/models/humhub.f.dart
@@ -21,7 +21,7 @@ class HumHubF extends HumHub {
   @override
   Map<String, String> get customHeaders => {
         'x-humhub-app-token': randomHash!,
-        'x-humhub-app': appVersion ?? '1.0.0',
+        'x-humhub-app': GlobalPackageInfo.info.version,
         'x-humhub-app-bundle-id': GlobalPackageInfo.info.packageName,
         'x-humhub-app-is-ios': isIos ? '1' : '0',
         'x-humhub-app-is-android': isAndroid ? '1' : '0',

--- a/lib/flavored/web_view.f.dart
+++ b/lib/flavored/web_view.f.dart
@@ -73,6 +73,7 @@ class FlavoredWebViewState extends ConsumerState<WebViewF> {
 
   @override
   Widget build(BuildContext context) {
+    ref.watch(humHubFRemoteConfigProvider);
     return PopScope(
       canPop: false,
       onPopInvokedWithResult: (didPop, result) => exitApp(context, ref),
@@ -128,12 +129,16 @@ class FlavoredWebViewState extends ConsumerState<WebViewF> {
       return NavigationActionPolicy.CANCEL;
     }
     // For SSO
-    if (!url.startsWith(instance.manifest.baseUrl) && action.isForMainFrame) {
+    if (!_supportsAuthClientRedirect &&
+        !url.startsWith(instance.manifest.startUrl) &&
+        action.isForMainFrame) {
+      logInfo(
+          'Legacy flavored SSO detected, launching AuthInAppBrowser for $url');
       _authBrowser.launchUrl(action.request);
       return NavigationActionPolicy.CANCEL;
     }
     // For all other external links
-    if (!url.startsWith(instance.manifest.baseUrl) && !action.isForMainFrame) {
+    if (!url.startsWith(instance.manifest.startUrl) && !action.isForMainFrame) {
       await launchUrl(action.request.url!.uriValue,
           mode: LaunchMode.externalApplication);
       return NavigationActionPolicy.CANCEL;
@@ -237,6 +242,18 @@ class FlavoredWebViewState extends ConsumerState<WebViewF> {
   Future<void> _handleJSMessage(
       ChannelMessage message, HeadlessInAppWebView headlessWebView) async {
     switch (message.action) {
+      case ChannelAction.authClientRedirect:
+        final data = message.data as AuthClientRedirectChannelData;
+        data.handle(
+          isSupported: _supportsAuthClientRedirect,
+          onIgnored: logInfo,
+          onLaunchable: (request, url) {
+            logInfo(
+                'Launching flavored AuthInAppBrowser from authClientRedirect for $url');
+            _authBrowser.launchUrl(request);
+          },
+        );
+        break;
       case ChannelAction.registerFcmDevice:
         String? token = ref.read(pushTokenProvider).value ??
             await FirebaseMessaging.instance.getTokenSafe();
@@ -277,6 +294,15 @@ class FlavoredWebViewState extends ConsumerState<WebViewF> {
       default:
         break;
     }
+  }
+
+  bool get _supportsAuthClientRedirect {
+    final remoteConfig = ref.read(humHubFRemoteConfigProvider).asData?.value;
+    final supportsAuthClientRedirect =
+        remoteConfig?.supportsAuthClientRedirect == true;
+    logDebug(
+        'Flavored authClientRedirect supported: $supportsAuthClientRedirect (${remoteConfig?.appVersion ?? 'unknown'})');
+    return supportsAuthClientRedirect;
   }
 
   Future<bool> exitApp(context, ref) async {

--- a/lib/flavored/web_view.f.dart
+++ b/lib/flavored/web_view.f.dart
@@ -8,6 +8,7 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:humhub/app_flavored.dart';
 import 'package:humhub/flavored/models/humhub.f.dart';
+import 'package:humhub/models/feature_flag.dart';
 import 'package:humhub/util/auth_in_app_browser.dart';
 import 'package:humhub/models/channel_message.dart';
 import 'package:humhub/util/black_list_rules.dart';
@@ -129,7 +130,7 @@ class FlavoredWebViewState extends ConsumerState<WebViewF> {
       return NavigationActionPolicy.CANCEL;
     }
     // For SSO
-    if (!_supportsAuthClientRedirect &&
+    if (!FeatureFlag.supportsAuthClientRedirect &&
         !url.startsWith(instance.manifest.startUrl) &&
         action.isForMainFrame) {
       logInfo(
@@ -245,7 +246,7 @@ class FlavoredWebViewState extends ConsumerState<WebViewF> {
       case ChannelAction.authClientRedirect:
         final data = message.data as AuthClientRedirectChannelData;
         data.handle(
-          isSupported: _supportsAuthClientRedirect,
+          isSupported: FeatureFlag.supportsAuthClientRedirect,
           onIgnored: logInfo,
           onLaunchable: (request, url) {
             logInfo(
@@ -294,15 +295,6 @@ class FlavoredWebViewState extends ConsumerState<WebViewF> {
       default:
         break;
     }
-  }
-
-  bool get _supportsAuthClientRedirect {
-    final remoteConfig = ref.read(humHubFRemoteConfigProvider).asData?.value;
-    final supportsAuthClientRedirect =
-        remoteConfig?.supportsAuthClientRedirect == true;
-    logDebug(
-        'Flavored authClientRedirect supported: $supportsAuthClientRedirect (${remoteConfig?.appVersion ?? 'unknown'})');
-    return supportsAuthClientRedirect;
   }
 
   Future<bool> exitApp(context, ref) async {

--- a/lib/models/channel_message.dart
+++ b/lib/models/channel_message.dart
@@ -150,7 +150,7 @@ class AuthClientRedirectChannelData extends ChannelData {
   }) {
     if (!isSupported) {
       onIgnored?.call(
-          'Ignoring authClientRedirect message because remote config version does not support it');
+          'Ignoring authClientRedirect message because app feature flags do not support it');
       return;
     }
 

--- a/lib/models/channel_message.dart
+++ b/lib/models/channel_message.dart
@@ -1,9 +1,22 @@
 import 'dart:convert';
 
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+
 import 'file_upload_settings.dart';
 
 /// Enum representing different channel actions
-enum ChannelAction { showOpener, hideOpener, registerFcmDevice, unregisterFcmDevice, updateNotificationCount, nativeConsole, fileUploadSettings, openExternal, none }
+enum ChannelAction {
+  showOpener,
+  hideOpener,
+  registerFcmDevice,
+  unregisterFcmDevice,
+  updateNotificationCount,
+  nativeConsole,
+  fileUploadSettings,
+  openExternal,
+  authClientRedirect,
+  none
+}
 
 /// Abstract class to encapsulate the logic for channel data
 abstract class ChannelData {
@@ -20,6 +33,8 @@ abstract class ChannelData {
         return UpdateNotificationCountChannelData.fromJson(type, json);
       case "fileUploadSettings":
         return FileUploadSettingsChannelData.fromJson(type, json);
+      case "authClientRedirect":
+        return AuthClientRedirectChannelData.fromJson(type, json);
       default:
         return DefaultChannelData(type);
     }
@@ -56,6 +71,8 @@ class ChannelMessage {
         return ChannelAction.fileUploadSettings;
       case "openExternal":
         return ChannelAction.openExternal;
+      case "authClientRedirect":
+        return ChannelAction.authClientRedirect;
       default:
         return ChannelAction.none;
     }
@@ -83,7 +100,8 @@ class RegisterFcmPushChannelData extends ChannelData {
 
   RegisterFcmPushChannelData(super.type, this.url);
 
-  factory RegisterFcmPushChannelData.fromJson(String type, Map<String, dynamic> json) {
+  factory RegisterFcmPushChannelData.fromJson(
+      String type, Map<String, dynamic> json) {
     return RegisterFcmPushChannelData(type, json['url'] as String?);
   }
 }
@@ -94,7 +112,8 @@ class UpdateNotificationCountChannelData extends ChannelData {
 
   UpdateNotificationCountChannelData(super.type, this.count);
 
-  factory UpdateNotificationCountChannelData.fromJson(String type, Map<String, dynamic> json) {
+  factory UpdateNotificationCountChannelData.fromJson(
+      String type, Map<String, dynamic> json) {
     return UpdateNotificationCountChannelData(type, json['count'] as int);
   }
 }
@@ -105,10 +124,49 @@ class FileUploadSettingsChannelData extends ChannelData {
 
   FileUploadSettingsChannelData(super.type, this.settings);
 
-  factory FileUploadSettingsChannelData.fromJson(String type, Map<String, dynamic> json) {
+  factory FileUploadSettingsChannelData.fromJson(
+      String type, Map<String, dynamic> json) {
     return FileUploadSettingsChannelData(
       type,
       FileUploadSettings.fromJson(json),
     );
+  }
+}
+
+class AuthClientRedirectChannelData extends ChannelData {
+  final String? url;
+
+  const AuthClientRedirectChannelData(super.type, this.url);
+
+  factory AuthClientRedirectChannelData.fromJson(
+      String type, Map<String, dynamic> json) {
+    return AuthClientRedirectChannelData(type, json['url'] as String?);
+  }
+
+  void handle({
+    required bool isSupported,
+    required void Function(URLRequest request, String url) onLaunchable,
+    void Function(String message)? onIgnored,
+  }) {
+    if (!isSupported) {
+      onIgnored?.call(
+          'Ignoring authClientRedirect message because remote config version does not support it');
+      return;
+    }
+
+    if (url == null || url!.isEmpty) {
+      onIgnored
+          ?.call('Ignoring authClientRedirect message because url is empty');
+      return;
+    }
+
+    final uri = Uri.tryParse(url!);
+    if (uri == null || !(uri.isScheme('http') || uri.isScheme('https'))) {
+      onIgnored
+          ?.call('Ignoring authClientRedirect message because url is invalid');
+      return;
+    }
+
+    onLaunchable(URLRequest(url: WebUri(url!)), url!);
   }
 }

--- a/lib/models/feature_flag.dart
+++ b/lib/models/feature_flag.dart
@@ -1,0 +1,38 @@
+import 'dart:convert';
+
+class FeatureFlag {
+  static const String authClientRedirectKey = 'auth_client_redirect';
+  static const String enabledValue = 'true';
+
+  static const FeatureFlag authClientRedirect = FeatureFlag(
+    key: authClientRedirectKey,
+    value: enabledValue,
+  );
+
+  final String key;
+  final String value;
+
+  const FeatureFlag({
+    required this.key,
+    required this.value,
+  });
+
+  Map<String, String> toJson() => {
+        'key': key,
+        'value': value,
+      };
+
+  static List<FeatureFlag> get featureFlags => const [
+        FeatureFlag.authClientRedirect,
+      ];
+
+  static String get featureFlagsHeaderValue => jsonEncode(
+        featureFlags.map((featureFlag) => featureFlag.toJson()).toList(),
+      );
+
+  static bool get supportsAuthClientRedirect => featureFlags.any(
+        (featureFlag) =>
+            featureFlag.key == authClientRedirectKey &&
+            featureFlag.value == enabledValue,
+      );
+}

--- a/lib/models/global_package_info.dart
+++ b/lib/models/global_package_info.dart
@@ -1,9 +1,20 @@
 import 'package:package_info_plus/package_info_plus.dart';
 
 class GlobalPackageInfo {
-  static late PackageInfo info;
+  static PackageInfo? _info;
+
+  static PackageInfo get info =>
+      _info ??
+      PackageInfo(
+        appName: '',
+        packageName: '',
+        version: '1.0.0',
+        buildNumber: '',
+        buildSignature: '',
+      );
 
   static Future<void> init() async {
-    info = await PackageInfo.fromPlatform();
+    _info = await PackageInfo.fromPlatform();
+    return;
   }
 }

--- a/lib/models/hum_hub.dart
+++ b/lib/models/hum_hub.dart
@@ -7,6 +7,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:humhub/app_flavored.dart';
 import 'package:humhub/app_opener.dart';
+import 'package:humhub/models/feature_flag.dart';
 import 'package:humhub/models/global_package_info.dart';
 import 'package:humhub/models/manifest.dart';
 import 'package:humhub/models/remote_config.dart';
@@ -169,6 +170,7 @@ class HumHub {
   Map<String, String> get customHeaders => {
         'x-humhub-app-token': randomHash ?? '',
         'x-humhub-app': GlobalPackageInfo.info.version,
+        'x-humhub-app-feature-flags': FeatureFlag.featureFlagsHeaderValue,
         'x-humhub-app-is-ios': isIos ? '1' : '0',
         'x-humhub-app-is-android': isAndroid ? '1' : '0',
         'x-humhub-app-opener-state': openerState.headerValue,

--- a/lib/models/hum_hub.dart
+++ b/lib/models/hum_hub.dart
@@ -69,7 +69,6 @@ class HumHub {
         'manifestUri': manifestUrl,
         'openerState': openerState.isShown,
         'randomHash': randomHash,
-        'appVersion': appVersion,
         'pushToken': pushToken,
         'history': history.map((manifest) => manifest.toJson()).toList(),
         'fileUploadSettings': fileUploadSettings?.toJson(),
@@ -85,7 +84,6 @@ class HumHub {
           ? OpenerState.shown
           : OpenerState.hidden,
       randomHash: json['randomHash'],
-      appVersion: json['appVersion'],
       pushToken: json['pushToken'],
       history: json['history'] != null
           ? List<Manifest>.from(
@@ -170,7 +168,7 @@ class HumHub {
 
   Map<String, String> get customHeaders => {
         'x-humhub-app-token': randomHash ?? '',
-        'x-humhub-app': appVersion ?? '1.0.0',
+        'x-humhub-app': GlobalPackageInfo.info.version,
         'x-humhub-app-is-ios': isIos ? '1' : '0',
         'x-humhub-app-is-android': isAndroid ? '1' : '0',
         'x-humhub-app-opener-state': openerState.headerValue,

--- a/lib/models/remote_config.dart
+++ b/lib/models/remote_config.dart
@@ -6,6 +6,7 @@ import 'package:loggy/loggy.dart';
 import 'manifest.dart';
 
 class RemoteConfig {
+  static const String _authClientRedirectVersion = '1.18.3';
   final String? appName;
   final String? appVersion;
   final FileUploadSettings? fileUploadSettings;
@@ -22,8 +23,13 @@ class RemoteConfig {
     return RemoteConfig(
       appName: json['appName'] as String,
       appVersion: json['appVersion'] as String,
-      fileUploadSettings: FileUploadSettings.fromJson(json['fileUploadSettings'] as Map<String, dynamic>),
-      whiteListedDomains: (json['whiteListedDomains'] as List<dynamic>).map((e) => Uri.tryParse(e as String)).where((uri) => uri != null).cast<Uri>().toList(),
+      fileUploadSettings: FileUploadSettings.fromJson(
+          json['fileUploadSettings'] as Map<String, dynamic>),
+      whiteListedDomains: (json['whiteListedDomains'] as List<dynamic>)
+          .map((e) => Uri.tryParse(e as String))
+          .where((uri) => uri != null)
+          .cast<Uri>()
+          .toList(),
     );
   }
 
@@ -32,11 +38,13 @@ class RemoteConfig {
       'appName': appName,
       'appVersion': appVersion,
       'fileUploadSettings': fileUploadSettings?.toJson(),
-      'whiteListedDomains': whiteListedDomains?.map((uri) => uri.toString()).toList(),
+      'whiteListedDomains':
+          whiteListedDomains?.map((uri) => uri.toString()).toList(),
     };
   }
 
-  static Future<RemoteConfig?> get(Manifest manifest, Map<String, dynamic>? headers) async {
+  static Future<RemoteConfig?> get(
+      Manifest manifest, Map<String, dynamic>? headers) async {
     try {
       final response = await Dio().get(
         '${manifest.startUrl}/mobile-app/get-settings',
@@ -63,5 +71,54 @@ class RemoteConfig {
       final trustedBase = '${trustedUri.scheme}://${trustedUri.authority}';
       return inputBase == trustedBase;
     });
+  }
+
+  bool get supportsAuthClientRedirect =>
+      _compareVersions(appVersion, _authClientRedirectVersion) >= 0;
+
+  static int _compareVersions(String? current, String target) {
+    final currentParts = _parseVersion(current);
+    final targetParts = _parseVersion(target);
+
+    if (currentParts == null || targetParts == null) {
+      return -1;
+    }
+
+    for (var index = 0; index < 3; index++) {
+      final difference = currentParts[index] - targetParts[index];
+      if (difference != 0) {
+        return difference;
+      }
+    }
+
+    return 0;
+  }
+
+  static List<int>? _parseVersion(String? version) {
+    if (version == null || version.isEmpty) {
+      return null;
+    }
+
+    final normalizedVersion = version.split('+').first.split('-').first.trim();
+    final parts = normalizedVersion.split('.');
+    if (parts.isEmpty) {
+      return null;
+    }
+
+    final parsed = <int>[];
+    for (var index = 0; index < 3; index++) {
+      if (index >= parts.length) {
+        parsed.add(0);
+        continue;
+      }
+
+      final value = int.tryParse(parts[index]);
+      if (value == null) {
+        return null;
+      }
+      parsed.add(value);
+    }
+
+    return parsed;
   }
 }

--- a/lib/models/remote_config.dart
+++ b/lib/models/remote_config.dart
@@ -6,7 +6,6 @@ import 'package:loggy/loggy.dart';
 import 'manifest.dart';
 
 class RemoteConfig {
-  static const String _authClientRedirectVersion = '1.18.3';
   final String? appName;
   final String? appVersion;
   final FileUploadSettings? fileUploadSettings;
@@ -71,54 +70,5 @@ class RemoteConfig {
       final trustedBase = '${trustedUri.scheme}://${trustedUri.authority}';
       return inputBase == trustedBase;
     });
-  }
-
-  bool get supportsAuthClientRedirect =>
-      _compareVersions(appVersion, _authClientRedirectVersion) >= 0;
-
-  static int _compareVersions(String? current, String target) {
-    final currentParts = _parseVersion(current);
-    final targetParts = _parseVersion(target);
-
-    if (currentParts == null || targetParts == null) {
-      return -1;
-    }
-
-    for (var index = 0; index < 3; index++) {
-      final difference = currentParts[index] - targetParts[index];
-      if (difference != 0) {
-        return difference;
-      }
-    }
-
-    return 0;
-  }
-
-  static List<int>? _parseVersion(String? version) {
-    if (version == null || version.isEmpty) {
-      return null;
-    }
-
-    final normalizedVersion = version.split('+').first.split('-').first.trim();
-    final parts = normalizedVersion.split('.');
-    if (parts.isEmpty) {
-      return null;
-    }
-
-    final parsed = <int>[];
-    for (var index = 0; index < 3; index++) {
-      if (index >= parts.length) {
-        parsed.add(0);
-        continue;
-      }
-
-      final value = int.tryParse(parts[index]);
-      if (value == null) {
-        return null;
-      }
-      parsed.add(value);
-    }
-
-    return parsed;
   }
 }

--- a/lib/pages/web_view.dart
+++ b/lib/pages/web_view.dart
@@ -368,9 +368,10 @@ class WebViewAppState extends ConsumerState<WebView> {
   }
 
   bool get _supportsAuthClientRedirect {
-    final remoteConfig = ref.read(humHubProvider).remoteConfig;
-    final supportsAuthClientRedirect = remoteConfig?.supportsAuthClientRedirect == true;
-    logDebug('authClientRedirect supported: $supportsAuthClientRedirect (${remoteConfig?.appVersion ?? 'unknown'})');
+    final supportsAuthClientRedirect =
+        ref.read(humHubProvider).supportsAuthClientRedirect;
+    logDebug(
+        'authClientRedirect supported by feature flags: $supportsAuthClientRedirect');
     return supportsAuthClientRedirect;
   }
 

--- a/lib/pages/web_view.dart
+++ b/lib/pages/web_view.dart
@@ -52,22 +52,17 @@ class WebViewAppState extends ConsumerState<WebView> {
   bool _isInit = false;
 
   StreamSubscription<bool>? _keyboardSubscription;
-  final KeyboardVisibilityController _keyboardVisibilityController =
-      KeyboardVisibilityController();
-  EdgeInsets get noKeyboardBottomPadding =>
-      MediaQuery.of(context).padding.copyWith(bottom: 0);
+  final KeyboardVisibilityController _keyboardVisibilityController = KeyboardVisibilityController();
+  EdgeInsets get noKeyboardBottomPadding => MediaQuery.of(context).padding.copyWith(bottom: 0);
   late EdgeInsets initKeyboardPadding = MediaQuery.of(context).padding;
   bool keyboardVisible = false;
 
   @override
   void initState() {
     super.initState();
-    _keyboardSubscription =
-        _keyboardVisibilityController.onChange.listen((bool visible) async {
+    _keyboardSubscription = _keyboardVisibilityController.onChange.listen((bool visible) async {
       keyboardVisible = visible;
-      await WebViewGlobalController.setWebViewSafeAreaPadding(
-          safeArea:
-              !keyboardVisible ? initKeyboardPadding : noKeyboardBottomPadding);
+      await WebViewGlobalController.setWebViewSafeAreaPadding(safeArea: !keyboardVisible ? initKeyboardPadding : noKeyboardBottomPadding);
     });
   }
 
@@ -82,14 +77,8 @@ class WebViewAppState extends ConsumerState<WebView> {
           color: HexColor(_manifest.themeColor),
         ),
         onRefresh: () async {
-          if (Platform.isAndroid) {
-            WebViewGlobalController.value?.reload();
-          } else if (Platform.isIOS) {
-            WebViewGlobalController.value?.loadUrl(
-                urlRequest: URLRequest(
-                    url: await WebViewGlobalController.value?.getUrl(),
-                    headers: ref.read(humHubProvider).customHeaders));
-          }
+          WebViewGlobalController.value
+              ?.loadUrl(urlRequest: URLRequest(url: await WebViewGlobalController.value?.getUrl(), headers: ref.read(humHubProvider).customHeaders));
         },
       );
       _authBrowser = AuthInAppBrowser(
@@ -126,15 +115,12 @@ class WebViewAppState extends ConsumerState<WebView> {
               onProgressChanged: _onProgressChanged,
               onReceivedError: _onReceivedError,
               onDownloadStartRequest: _onDownloadStartRequest,
-              onLongPressHitTestResult:
-                  WebViewGlobalController.onLongPressHitTestResult,
+              onLongPressHitTestResult: WebViewGlobalController.onLongPressHitTestResult,
               onReceivedHttpError: (controller, request, errorResponse) {
                 logError(errorResponse);
               },
               onPermissionRequest: (controller, request) async {
-                return PermissionResponse(
-                    resources: request.resources,
-                    action: PermissionResponseAction.GRANT);
+                return PermissionResponse(resources: request.resources, action: PermissionResponseAction.GRANT);
               },
             ),
           ),
@@ -165,25 +151,17 @@ class WebViewAppState extends ConsumerState<WebView> {
     }
     String? payloadFromPush = InitFromUrl.usePayload();
     if (payloadFromPush != null) url = payloadFromPush;
-    return URLRequest(
-        url: WebUri(url ?? _manifest.startUrl),
-        headers: ref.read(humHubProvider).customHeaders);
+    return URLRequest(url: WebUri(url ?? _manifest.startUrl), headers: ref.read(humHubProvider).customHeaders);
   }
 
-  Future<NavigationActionPolicy?> _shouldOverrideUrlLoading(
-      InAppWebViewController controller, NavigationAction action) async {
-    WebViewGlobalController.ajaxSetHeaders(
-        headers: ref.read(humHubProvider).customHeaders);
+  Future<NavigationActionPolicy?> _shouldOverrideUrlLoading(InAppWebViewController controller, NavigationAction action) async {
+    WebViewGlobalController.ajaxSetHeaders(headers: ref.read(humHubProvider).customHeaders);
     WebViewGlobalController.listenToImageOpen();
     WebViewGlobalController.appendViewportFitCover();
-    await WebViewGlobalController.setWebViewSafeAreaPadding(
-        safeArea:
-            !keyboardVisible ? initKeyboardPadding : noKeyboardBottomPadding);
+    await WebViewGlobalController.setWebViewSafeAreaPadding(safeArea: !keyboardVisible ? initKeyboardPadding : noKeyboardBottomPadding);
 
-    if (WebViewGlobalController.isCommonURIScheme(
-        webUri: action.request.url!)) {
-      return WebViewGlobalController.handleCommonURISchemes(
-          webUri: action.request.url!);
+    if (WebViewGlobalController.isCommonURIScheme(webUri: action.request.url!)) {
+      return WebViewGlobalController.handleCommonURISchemes(webUri: action.request.url!);
     }
 
     final url = action.request.url!.rawValue;
@@ -196,35 +174,21 @@ class WebViewAppState extends ConsumerState<WebView> {
       return NavigationActionPolicy.CANCEL;
     }
     // For SSO
-    bool? isDomainTrusted = ref
-            .read(humHubProvider)
-            .remoteConfig
-            ?.isTrustedDomain(action.request.url!.uriValue) ??
-        false;
-    if ((!url.startsWith(_manifest.baseUrl) && action.isForMainFrame) &&
-        !isDomainTrusted) {
-      logInfo('SSO detected, launching AuthInAppBrowser for $url');
+    bool? isDomainTrusted = ref.read(humHubProvider).remoteConfig?.isTrustedDomain(action.request.url!.uriValue) ?? false;
+    if ((!url.startsWith(_manifest.startUrl) && action.isForMainFrame) && !_supportsAuthClientRedirect && !isDomainTrusted) {
+      logInfo('Legacy SSO detected, launching AuthInAppBrowser for $url');
       _authBrowser.launchUrl(action.request);
       return NavigationActionPolicy.CANCEL;
     }
     // For all other external links
-    if (!url.startsWith(_manifest.baseUrl) &&
-        !action.isForMainFrame &&
-        action.navigationType == NavigationType.LINK_ACTIVATED) {
-      logInfo(
-          'External link detected, launching external application for $url');
-      await launchUrl(action.request.url!.uriValue,
-          mode: LaunchMode.externalApplication);
+    if (!url.startsWith(_manifest.startUrl) && !action.isForMainFrame && action.navigationType == NavigationType.LINK_ACTIVATED) {
+      logInfo('External link detected, launching external application for $url');
+      await launchUrl(action.request.url!.uriValue, mode: LaunchMode.externalApplication);
       return NavigationActionPolicy.CANCEL;
     }
     // 2nd Append customHeader if url is in app redirect and CANCEL the requests without custom headers
-    if (Platform.isAndroid ||
-        action.navigationType == NavigationType.LINK_ACTIVATED ||
-        action.navigationType == NavigationType.FORM_SUBMITTED) {
-      Map<String, String> mergedMap = {
-        ...?_initialRequest.headers,
-        ...?action.request.headers
-      };
+    if (Platform.isAndroid || action.navigationType == NavigationType.LINK_ACTIVATED || action.navigationType == NavigationType.FORM_SUBMITTED) {
+      Map<String, String> mergedMap = {...?_initialRequest.headers, ...?action.request.headers};
       URLRequest newRequest = action.request.copyWith(headers: mergedMap);
       controller.loadUrl(urlRequest: newRequest);
       return NavigationActionPolicy.CANCEL;
@@ -239,8 +203,7 @@ class WebViewAppState extends ConsumerState<WebView> {
     await controller.addWebMessageListener(
       WebMessageListener(
         jsObjectName: "flutterChannel",
-        onPostMessage:
-            (inMessage, sourceOrigin, isMainFrame, replyProxy) async {
+        onPostMessage: (inMessage, sourceOrigin, isMainFrame, replyProxy) async {
           logInfo(inMessage);
           ChannelMessage message = ChannelMessage.fromJson(inMessage!.data);
           await _handleJSMessage(message, _headlessWebView!);
@@ -251,15 +214,13 @@ class WebViewAppState extends ConsumerState<WebView> {
     WebViewGlobalController.setValue(controller);
   }
 
-  Future<FetchRequest?> _shouldInterceptFetchRequest(
-      InAppWebViewController controller, FetchRequest request) async {
+  Future<FetchRequest?> _shouldInterceptFetchRequest(InAppWebViewController controller, FetchRequest request) async {
     logDebug("_shouldInterceptFetchRequest");
     request.headers?.addAll(_initialRequest.headers!);
     return request;
   }
 
-  Future<bool?> _onCreateWindow(InAppWebViewController controller,
-      CreateWindowAction createWindowAction) async {
+  Future<bool?> _onCreateWindow(InAppWebViewController controller, CreateWindowAction createWindowAction) async {
     WebUri? urlToOpen = createWindowAction.request.url;
 
     if (urlToOpen == null) return Future.value(false);
@@ -285,26 +246,20 @@ class WebViewAppState extends ConsumerState<WebView> {
     if (url!.path.contains('/user/auth/login')) {
       WebViewGlobalController.setLoginForm();
     }
-    WebViewGlobalController.ajaxSetHeaders(
-        headers: ref.read(humHubProvider).customHeaders);
+    WebViewGlobalController.ajaxSetHeaders(headers: ref.read(humHubProvider).customHeaders);
     WebViewGlobalController.listenToImageOpen();
     WebViewGlobalController.appendViewportFitCover();
-    await WebViewGlobalController.setWebViewSafeAreaPadding(
-        safeArea:
-            !keyboardVisible ? initKeyboardPadding : noKeyboardBottomPadding);
+    await WebViewGlobalController.setWebViewSafeAreaPadding(safeArea: !keyboardVisible ? initKeyboardPadding : noKeyboardBottomPadding);
 
     LoadingProvider.of(ref).dismissAll();
   }
 
   void _onLoadStart(InAppWebViewController controller, Uri? url) async {
     logDebug('Page load started: $url');
-    WebViewGlobalController.ajaxSetHeaders(
-        headers: ref.read(humHubProvider).customHeaders);
+    WebViewGlobalController.ajaxSetHeaders(headers: ref.read(humHubProvider).customHeaders);
     WebViewGlobalController.listenToImageOpen();
     WebViewGlobalController.appendViewportFitCover();
-    await WebViewGlobalController.setWebViewSafeAreaPadding(
-        safeArea:
-            !keyboardVisible ? initKeyboardPadding : noKeyboardBottomPadding);
+    await WebViewGlobalController.setWebViewSafeAreaPadding(safeArea: !keyboardVisible ? initKeyboardPadding : noKeyboardBottomPadding);
   }
 
   _onProgressChanged(InAppWebViewController controller, int progress) {
@@ -314,12 +269,8 @@ class WebViewAppState extends ConsumerState<WebView> {
     }
   }
 
-  void _onReceivedError(InAppWebViewController controller,
-      WebResourceRequest request, WebResourceError error) {
-    if ([
-      WebResourceErrorType.NOT_CONNECTED_TO_INTERNET,
-      WebResourceErrorType.TIMEOUT
-    ].contains(error.type)) {
+  void _onReceivedError(InAppWebViewController controller, WebResourceRequest request, WebResourceError error) {
+    if ([WebResourceErrorType.NOT_CONNECTED_TO_INTERNET, WebResourceErrorType.TIMEOUT].contains(error.type)) {
       logWarning('No internet connection detected');
       LoadingProvider.of(ref).dismissAll();
     }
@@ -327,17 +278,27 @@ class WebViewAppState extends ConsumerState<WebView> {
 
   _concludeAuth(URLRequest request) {
     _authBrowser.close();
+    WebViewGlobalController.value!.clearHistory();
     WebViewGlobalController.value!.loadUrl(urlRequest: request);
   }
 
-  Future<void> _handleJSMessage(
-      ChannelMessage message, HeadlessInAppWebView headlessWebView) async {
+  Future<void> _handleJSMessage(ChannelMessage message, HeadlessInAppWebView headlessWebView) async {
     switch (message.action) {
+      case ChannelAction.authClientRedirect:
+        final data = message.data as AuthClientRedirectChannelData;
+        data.handle(
+          isSupported: _supportsAuthClientRedirect,
+          onIgnored: logInfo,
+          onLaunchable: (request, url) {
+            logInfo('Launching AuthInAppBrowser from authClientRedirect for $url');
+            _authBrowser.launchUrl(request);
+          },
+        );
+        break;
       case ChannelAction.showOpener:
         logInfo('Action: showOpener');
         ref.read(humHubProvider).setOpenerState(OpenerState.shown);
-        Navigator.of(context).pushNamedAndRemoveUntil(
-            OpenerPage.path, (Route<dynamic> route) => false);
+        Navigator.of(context).pushNamedAndRemoveUntil(OpenerPage.path, (Route<dynamic> route) => false);
         break;
       case ChannelAction.hideOpener:
         logInfo('Action: hideOpener');
@@ -348,8 +309,7 @@ class WebViewAppState extends ConsumerState<WebView> {
         break;
       case ChannelAction.registerFcmDevice:
         logInfo('Action: registerFcmDevice');
-        String? token = ref.read(pushTokenProvider).value ??
-            await FirebaseMessaging.instance.getTokenSafe();
+        String? token = ref.read(pushTokenProvider).value ?? await FirebaseMessaging.instance.getTokenSafe();
         if (token != null) {
           WebViewGlobalController.ajaxPost(
             url: message.url!,
@@ -360,8 +320,7 @@ class WebViewAppState extends ConsumerState<WebView> {
         break;
       case ChannelAction.updateNotificationCount:
         logInfo('Action: updateNotificationCount');
-        UpdateNotificationCountChannelData data =
-            message.data as UpdateNotificationCountChannelData;
+        UpdateNotificationCountChannelData data = message.data as UpdateNotificationCountChannelData;
         AppBadgePlus.updateBadge(data.count);
         break;
       case ChannelAction.nativeConsole:
@@ -370,8 +329,7 @@ class WebViewAppState extends ConsumerState<WebView> {
         break;
       case ChannelAction.unregisterFcmDevice:
         logInfo('Action: unregisterFcmDevice');
-        String? token = ref.read(pushTokenProvider).value ??
-            await FirebaseMessaging.instance.getTokenSafe();
+        String? token = ref.read(pushTokenProvider).value ?? await FirebaseMessaging.instance.getTokenSafe();
         if (token != null) {
           WebViewGlobalController.ajaxPost(
             url: message.url!,
@@ -382,8 +340,7 @@ class WebViewAppState extends ConsumerState<WebView> {
         break;
       case ChannelAction.fileUploadSettings:
         logInfo('Action: fileUploadSettings');
-        FileUploadSettingsChannelData data =
-            message.data as FileUploadSettingsChannelData;
+        FileUploadSettingsChannelData data = message.data as FileUploadSettingsChannelData;
         ref.read(humHubProvider.notifier).setFileUploadSettings(data.settings);
         FileUploadManager(
                 webViewController: WebViewGlobalController.value!,
@@ -410,6 +367,13 @@ class WebViewAppState extends ConsumerState<WebView> {
     }
   }
 
+  bool get _supportsAuthClientRedirect {
+    final remoteConfig = ref.read(humHubProvider).remoteConfig;
+    final supportsAuthClientRedirect = remoteConfig?.supportsAuthClientRedirect == true;
+    logDebug('authClientRedirect supported: $supportsAuthClientRedirect (${remoteConfig?.appVersion ?? 'unknown'})');
+    return supportsAuthClientRedirect;
+  }
+
   Future<bool> exitApp(BuildContext context, WidgetRef ref) async {
     logInfo('Attempting to exit app');
     bool canGoBack = await WebViewGlobalController.value!.canGoBack();
@@ -424,12 +388,9 @@ class WebViewAppState extends ConsumerState<WebView> {
         exitConfirmed = await showDialog<bool>(
           context: context,
           builder: (context) => AlertDialog(
-            shape: const RoundedRectangleBorder(
-                borderRadius: BorderRadius.all(Radius.circular(10.0))),
-            title:
-                Text(AppLocalizations.of(context)!.web_view_exit_popup_title),
-            content:
-                Text(AppLocalizations.of(context)!.web_view_exit_popup_content),
+            shape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(10.0))),
+            title: Text(AppLocalizations.of(context)!.web_view_exit_popup_title),
+            content: Text(AppLocalizations.of(context)!.web_view_exit_popup_content),
             actions: <Widget>[
               TextButton(
                 onPressed: () => Navigator.of(context).pop(false),
@@ -438,8 +399,7 @@ class WebViewAppState extends ConsumerState<WebView> {
               TextButton(
                 onPressed: () {
                   ref.read(humHubProvider).openerState.isShown
-                      ? Navigator.of(context).pushNamedAndRemoveUntil(
-                          OpenerPage.path, (Route<dynamic> route) => false)
+                      ? Navigator.of(context).pushNamedAndRemoveUntil(OpenerPage.path, (Route<dynamic> route) => false)
                       : SystemNavigator.pop();
                 },
                 child: Text(AppLocalizations.of(context)!.yes),
@@ -452,8 +412,7 @@ class WebViewAppState extends ConsumerState<WebView> {
     }
   }
 
-  void _onDownloadStartRequest(InAppWebViewController controller,
-      DownloadStartRequest downloadStartRequest) async {
+  void _onDownloadStartRequest(InAppWebViewController controller, DownloadStartRequest downloadStartRequest) async {
     logInfo('Download started: ${downloadStartRequest.url}');
     PersistentBottomSheetController? persistentController;
 
@@ -474,8 +433,7 @@ class WebViewAppState extends ConsumerState<WebView> {
         isDone = true;
         Keys.scaffoldMessengerStateKey.currentState?.showSnackBar(
           SnackBar(
-            content: Text(
-                '${AppLocalizations.of(context)!.file_download}: $filename'),
+            content: Text('${AppLocalizations.of(context)!.file_download}: $filename'),
             action: SnackBarAction(
               label: AppLocalizations.of(context)!.open,
               onPressed: () {
@@ -492,22 +450,19 @@ class WebViewAppState extends ConsumerState<WebView> {
         downloadTimer = Timer(const Duration(seconds: 1), () {
           // Show the persistent bottom sheet if not already shown
           if (!isDone) {
-            persistentController =
-                _scaffoldKey.currentState!.showBottomSheet((context) {
+            persistentController = _scaffoldKey.currentState!.showBottomSheet((context) {
               return Container(
                 width: MediaQuery.of(context).size.width,
                 height: 100,
                 color: const Color(0xff313033),
                 child: Padding(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+                  padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
                   child: Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
                       Text(
                         "${AppLocalizations.of(context)!.downloading}...",
-                        style: const TextStyle(
-                            fontWeight: FontWeight.bold, color: Colors.white),
+                        style: const TextStyle(fontWeight: FontWeight.bold, color: Colors.white),
                       ),
                       Stack(
                         alignment: Alignment.center,

--- a/lib/util/auth_in_app_browser.dart
+++ b/lib/util/auth_in_app_browser.dart
@@ -21,6 +21,7 @@ class AuthInAppBrowser extends InAppBrowser {
         shouldCloseOnBackButtonPressed: true,
         toolbarTopBackgroundColor: Colors.white,
         toolbarTopTintColor: HexColor(manifest.themeColor),
+        toolbarTopTranslucent: false,
         presentationStyle: ModalPresentationStyle.PAGE_SHEET,
       ),
       webViewSettings: InAppWebViewSettings(
@@ -32,10 +33,11 @@ class AuthInAppBrowser extends InAppBrowser {
   }
 
   @override
-  Future<NavigationActionPolicy?>? shouldOverrideUrlLoading(NavigationAction navigationAction) async {
+  Future<NavigationActionPolicy?>? shouldOverrideUrlLoading(
+      NavigationAction navigationAction) async {
     logInfo("Browser closed!");
 
-    if (navigationAction.request.url!.origin.startsWith(manifest.baseUrl)) {
+    if (navigationAction.request.url!.toString().startsWith(manifest.startUrl)) {
       concludeAuth(navigationAction.request);
       return NavigationActionPolicy.CANCEL;
     }

--- a/lib/util/providers.dart
+++ b/lib/util/providers.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:humhub/models/feature_flag.dart';
 import 'package:humhub/models/file_upload_settings.dart';
 import 'package:humhub/models/hum_hub.dart';
 import 'package:humhub/models/manifest.dart';
@@ -20,6 +21,7 @@ class HumHubNotifier extends ChangeNotifier {
   String? get pushToken => _humHubInstance.pushToken;
   String? get manifestUrl => _humHubInstance.manifestUrl;
   Map<String, String> get customHeaders => _humHubInstance.customHeaders;
+  bool get supportsAuthClientRedirect => FeatureFlag.supportsAuthClientRedirect;
   RemoteConfig? get remoteConfig => _humHubInstance.remoteConfig;
   List<Manifest> get history => _humHubInstance.history;
   FileUploadSettings? get fileUploadSettings => _humHubInstance.fileUploadSettings;


### PR DESCRIPTION
 - introduce a dedicated `FeatureFlag` DTO to define supported app capabilities and serialize them into request headers
- send the current installed app version from `PackageInfo` in `x-humhub-app` instead of relying on the previously cached `appVersion` field
- remove `appVersion` from persisted `HumHub` state so app upgrades always send the latest installed version
- add `authClientRedirect` parsing and handling to channel messages
- update opener and flavored web views to handle `authClientRedirect` messages and launch the in-app auth browser when needed